### PR TITLE
등급 수정 시 나타났던 null값 에러

### DIFF
--- a/application/src/main/java/com/project/controller/admin/AdminUserController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminUserController.java
@@ -44,6 +44,11 @@ public class AdminUserController {
 
     @PostMapping("grade")
     public List<Grade> updateGrade(@RequestBody List<Grade> grades) {
+        // 등급 수정 시 order_history 테이블의 point_earned_amount 컬럼과
+        // point_used_amount 컬럼값에 null값을 가지고 있는 행들이 존재하였음.
+        // OrderHistory 엔티티의 자료형이 int이기 때문에 null 값을 담을 수 없어 오류가 남
+        // Grade를 업데이트 하였는데 OrderHistory 쪽에서 오류가 나는 이유는 아직 발견하지 못함.
+        // order_history 테이블의 null 값들을 모두 0으로 수정 후 해결
         return adminUserService.updateGrades(grades);
     }
 

--- a/application/src/main/java/com/project/controller/admin/AdminUserController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminUserController.java
@@ -44,11 +44,7 @@ public class AdminUserController {
 
     @PostMapping("grade")
     public List<Grade> updateGrade(@RequestBody List<Grade> grades) {
-        // 등급 수정 시 order_history 테이블의 point_earned_amount 컬럼과
-        // point_used_amount 컬럼값에 null값을 가지고 있는 행들이 존재하였음.
-        // OrderHistory 엔티티의 자료형이 int이기 때문에 null 값을 담을 수 없어 오류가 남
-        // Grade를 업데이트 하였는데 OrderHistory 쪽에서 오류가 나는 이유는 아직 발견하지 못함.
-        // order_history 테이블의 null 값들을 모두 0으로 수정 후 해결
+        // 등급 수정 에러 해결
         return adminUserService.updateGrades(grades);
     }
 

--- a/frontend/src/components/admin/content/user/UserGrade.jsx
+++ b/frontend/src/components/admin/content/user/UserGrade.jsx
@@ -30,6 +30,7 @@ const UserGrade = () => {
       }
     );
     // .filter((grade) => grade.grade !== '');
+    console.log(updateGrades);
     updateGrade(updateGrades);
     alert('저장되었습니다!');
     fetchGrades();


### PR DESCRIPTION
## 문제 요약 ##
등급 수정 시 `order_history` 테이블의 `point_earned_amount` 컬럼과
`point_used_amount` 컬럼값에 `null`값을 가지고 있는 행들이 존재하였음.

## 원인 분석 ##
`OrderHistory` 엔티티의 자료형이 `int`이기 때문에 `null` 값을 담을 수 없어 오류가 남

## 해결 방법 ##
`order_history` 테이블의 `null` 값들을 모두 `0`으로 수정 후 해결

## 남은 문제 ##
`Grade`를 업데이트 하였는데 `OrderHistory` 쪽에서 오류가 나는 이유는 아직 발견하지 못함.