### PR TITLE
Exchange_item , refund_item 컬럼 수정 및 추가

### DIFF
--- a/application/src/main/java/com/project/controller/admin/AdminOrderController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminOrderController.java
@@ -34,6 +34,11 @@ public class AdminOrderController {
         return adminOrderService.getExchange(pageable,pageRequestDTO);
     }
 
+    @GetMapping("refund")
+    public Page<AdminRefundDTO> getRefund(@PageableDefault(size = 20,direction = Sort.Direction.DESC)Pageable pageable, @ModelAttribute PageRequestDTO pageRequestDTO) {
+        return adminOrderService.getRefund(pageable,pageRequestDTO);
+    }
+
     @GetMapping("month")
     public List<AdminOrderMonthDTO> getOrderMonth(){
         return adminOrderService.getOrderMonth();

--- a/application/src/main/java/com/project/controller/admin/AdminOrderController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminOrderController.java
@@ -31,6 +31,7 @@ public class AdminOrderController {
 
     @GetMapping("exchange")
     public Page<AdminExchangeDTO> getExchange(@PageableDefault(size = 20,direction = Sort.Direction.DESC)Pageable pageable, @ModelAttribute PageRequestDTO pageRequestDTO) {
+        System.out.println(pageRequestDTO.getSearchInput());
         return adminOrderService.getExchange(pageable,pageRequestDTO);
     }
 

--- a/application/src/main/java/com/project/controller/admin/AdminOrderController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminOrderController.java
@@ -29,6 +29,11 @@ public class AdminOrderController {
         return adminOrderService.getDelivery(pageable,pageRequestDTO);
     }
 
+    @GetMapping("exchange")
+    public Page<AdminExchangeDTO> getExchange(@PageableDefault(size = 20,direction = Sort.Direction.DESC)Pageable pageable, @ModelAttribute PageRequestDTO pageRequestDTO) {
+        return adminOrderService.getExchange(pageable,pageRequestDTO);
+    }
+
     @GetMapping("month")
     public List<AdminOrderMonthDTO> getOrderMonth(){
         return adminOrderService.getOrderMonth();

--- a/application/src/main/java/com/project/controller/admin/AdminUserController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminUserController.java
@@ -44,6 +44,11 @@ public class AdminUserController {
 
     @PostMapping("grade")
     public List<Grade> updateGrade(@RequestBody List<Grade> grades) {
+        // 등급 수정 시 order_history 테이블의 point_earned_amount 컬럼과
+        // point_used_amount 컬럼값에 null값을 가지고 있는 행들이 존재하였음.
+        // OrderHistory 엔티티의 자료형이 int이기 때문에 null 값을 담을 수 없어 오류가 남
+        // Grade를 업데이트 하였는데 OrderHistory 쪽에서 오류가 나는 이유는 아직 발견하지 못함.
+        // order_history 테이블의 null 값들을 모두 0으로 수정 후 해결
         return adminUserService.updateGrades(grades);
     }
 

--- a/application/src/main/java/com/project/controller/admin/AdminUserController.java
+++ b/application/src/main/java/com/project/controller/admin/AdminUserController.java
@@ -44,11 +44,7 @@ public class AdminUserController {
 
     @PostMapping("grade")
     public List<Grade> updateGrade(@RequestBody List<Grade> grades) {
-        // 등급 수정 시 order_history 테이블의 point_earned_amount 컬럼과
-        // point_used_amount 컬럼값에 null값을 가지고 있는 행들이 존재하였음.
-        // OrderHistory 엔티티의 자료형이 int이기 때문에 null 값을 담을 수 없어 오류가 남
-        // Grade를 업데이트 하였는데 OrderHistory 쪽에서 오류가 나는 이유는 아직 발견하지 못함.
-        // order_history 테이블의 null 값들을 모두 0으로 수정 후 해결
+        // 등급 수정 에러 해결
         return adminUserService.updateGrades(grades);
     }
 

--- a/application/src/main/java/com/project/domain/ExchangeItem.java
+++ b/application/src/main/java/com/project/domain/ExchangeItem.java
@@ -1,0 +1,26 @@
+package com.project.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Entity
+public class ExchangeItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_history_id",referencedColumnName = "id")
+    @JsonIgnore
+    private OrderHistory orderHistory;
+
+    private String exchangeImage;
+    private String exchangeDeliveryNumber;
+    private Timestamp requestedAt;
+    private Timestamp completedAt;
+    private String description;
+}

--- a/application/src/main/java/com/project/domain/RefundItem.java
+++ b/application/src/main/java/com/project/domain/RefundItem.java
@@ -22,5 +22,6 @@ public class RefundItem {
     private String refundDeliveryNumber;
     private Timestamp requestedAt;
     private Timestamp completedAt;
+    private String description;
 
 }

--- a/application/src/main/java/com/project/domain/RefundItem.java
+++ b/application/src/main/java/com/project/domain/RefundItem.java
@@ -1,0 +1,26 @@
+package com.project.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Entity
+public class RefundItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_history_id",referencedColumnName = "id")
+    @JsonIgnore
+    private OrderHistory orderHistory;
+
+    private String refundImage;
+    private String refundDeliveryNumber;
+    private Timestamp requestedAt;
+    private Timestamp completedAt;
+
+}

--- a/application/src/main/java/com/project/dto/AdminExchangeDTO.java
+++ b/application/src/main/java/com/project/dto/AdminExchangeDTO.java
@@ -9,10 +9,11 @@ import java.sql.Timestamp;
 @AllArgsConstructor
 public class AdminExchangeDTO {
     private Long id;
+    private String email;
     private Timestamp orderDate;
     private Timestamp requestedDate;
-    private int orderNo;
+    private int orderNumber;
     private String exchangeImage;
     private String itemName;
-    private String exchangeDescription;
+    private String description;
 }

--- a/application/src/main/java/com/project/dto/AdminExchangeDTO.java
+++ b/application/src/main/java/com/project/dto/AdminExchangeDTO.java
@@ -1,0 +1,18 @@
+package com.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class AdminExchangeDTO {
+    private Long id;
+    private Timestamp orderDate;
+    private Timestamp requestedDate;
+    private int orderNo;
+    private String exchangeImage;
+    private String itemName;
+    private String exchangeDescription;
+}

--- a/application/src/main/java/com/project/dto/AdminRefundDTO.java
+++ b/application/src/main/java/com/project/dto/AdminRefundDTO.java
@@ -9,10 +9,11 @@ import java.sql.Timestamp;
 @AllArgsConstructor
 public class AdminRefundDTO {
     private Long id;
+    private String email;
     private Timestamp orderDate;
     private Timestamp requestedDate;
-    private int orderNo;
+    private int orderNumber;
     private String refundImage;
     private String itemName;
-    private String refundDescription;
+    private String description;
 }

--- a/application/src/main/java/com/project/dto/AdminRefundDTO.java
+++ b/application/src/main/java/com/project/dto/AdminRefundDTO.java
@@ -1,0 +1,18 @@
+package com.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class AdminRefundDTO {
+    private Long id;
+    private Timestamp orderDate;
+    private Timestamp requestedDate;
+    private int orderNo;
+    private String refundImage;
+    private String itemName;
+    private String refundDescription;
+}

--- a/application/src/main/java/com/project/repository/admin/AdminExchangeRepository.java
+++ b/application/src/main/java/com/project/repository/admin/AdminExchangeRepository.java
@@ -14,11 +14,11 @@ import java.sql.Timestamp;
 @Repository
 public interface AdminExchangeRepository extends JpaRepository<ExchangeItem,Long> {
     @Query("SELECT new com.project.dto.AdminExchangeDTO(" +
-            "e.id, oh.paymentDate,e.requestedAt,oh.orderNumber,e.exchangeImage,od.itemName,e.description)" +
+            "e.id,u.email, oh.paymentDate,e.requestedAt,oh.orderNumber,e.exchangeImage,od.itemName,e.description)" +
             "FROM ExchangeItem e " +
-            "LEFT JOIN e.orderHistory oh " +
-            "LEFT JOIN oh.orderDetails od " +
-            "LEFT JOIN oh.user u " +
+            "JOIN e.orderHistory oh " +
+            "JOIN oh.orderDetails od " +
+            "JOIN oh.user u " +
             "WHERE ((:searchKeyword IS NULL OR :searchInput = '') OR " +
             "(:searchKeyword ='orderNo' AND CONCAT('', oh.orderNumber) LIKE CONCAT('%',:searchInput,'%')) OR " +
             "(:searchKeyword ='email' AND u.email LIKE CONCAT('%',:searchInput,'%')) OR " +

--- a/application/src/main/java/com/project/repository/admin/AdminExchangeRepository.java
+++ b/application/src/main/java/com/project/repository/admin/AdminExchangeRepository.java
@@ -1,0 +1,33 @@
+package com.project.repository.admin;
+
+import com.project.domain.ExchangeItem;
+import com.project.dto.AdminExchangeDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+
+@Repository
+public interface AdminExchangeRepository extends JpaRepository<ExchangeItem,Long> {
+    @Query("SELECT new com.project.dto.AdminExchangeDTO(" +
+            "e.id, oh.paymentDate,e.requestedAt,oh.orderNumber,e.exchangeImage,od.itemName,e.description)" +
+            "FROM ExchangeItem e " +
+            "LEFT JOIN e.orderHistory oh " +
+            "LEFT JOIN oh.orderDetails od " +
+            "LEFT JOIN oh.user u " +
+            "WHERE ((:searchKeyword IS NULL OR :searchInput = '') OR " +
+            "(:searchKeyword ='orderNo' AND CONCAT('', oh.orderNumber) LIKE CONCAT('%',:searchInput,'%')) OR " +
+            "(:searchKeyword ='email' AND u.email LIKE CONCAT('%',:searchInput,'%')) OR " +
+            "(:searchKeyword ='itemName' AND od.itemName LIKE CONCAT('%',:searchInput,'%')))"+
+            "AND (:startDate IS NULL OR oh.paymentDate >= :startDate)" +
+            "AND (:endDate IS NULL OR oh.paymentDate <= :endDate)")
+    Page<AdminExchangeDTO> findExchange(Pageable pageable,
+                                        @Param("searchKeyword")String searchKeyword,
+                                        @Param("searchInput")String searchInput,
+                                        @Param("startDate") Timestamp startDate,
+                                        @Param("endDate")Timestamp endDate);
+}

--- a/application/src/main/java/com/project/repository/admin/AdminRefundRepository.java
+++ b/application/src/main/java/com/project/repository/admin/AdminRefundRepository.java
@@ -14,11 +14,11 @@ import java.sql.Timestamp;
 @Repository
 public interface AdminRefundRepository extends JpaRepository<RefundItem, Long> {
     @Query("SELECT new com.project.dto.AdminRefundDTO(" +
-            "r.id, oh.paymentDate,r.requestedAt,oh.orderNumber,r.refundImage,od.itemName,r.description)" +
+            "r.id,u.email, oh.paymentDate,r.requestedAt,oh.orderNumber,r.refundImage,od.itemName,r.description)" +
             "FROM RefundItem r " +
-            "LEFT JOIN r.orderHistory oh " +
-            "LEFT JOIN oh.orderDetails od " +
-            "LEFT JOIN oh.user u " +
+            "JOIN r.orderHistory oh " +
+            "JOIN oh.orderDetails od " +
+            "JOIN oh.user u " +
             "WHERE ((:searchKeyword IS NULL OR :searchInput = '') OR " +
             "(:searchKeyword ='orderNo' AND CONCAT('', oh.orderNumber) LIKE CONCAT('%',:searchInput,'%')) OR " +
             "(:searchKeyword ='email' AND u.email LIKE CONCAT('%',:searchInput,'%')) OR " +

--- a/application/src/main/java/com/project/repository/admin/AdminRefundRepository.java
+++ b/application/src/main/java/com/project/repository/admin/AdminRefundRepository.java
@@ -1,0 +1,33 @@
+package com.project.repository.admin;
+
+import com.project.domain.RefundItem;
+import com.project.dto.AdminRefundDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+
+@Repository
+public interface AdminRefundRepository extends JpaRepository<RefundItem, Long> {
+    @Query("SELECT new com.project.dto.AdminRefundDTO(" +
+            "r.id, oh.paymentDate,r.requestedAt,oh.orderNumber,r.refundImage,od.itemName,r.description)" +
+            "FROM RefundItem r " +
+            "LEFT JOIN r.orderHistory oh " +
+            "LEFT JOIN oh.orderDetails od " +
+            "LEFT JOIN oh.user u " +
+            "WHERE ((:searchKeyword IS NULL OR :searchInput = '') OR " +
+            "(:searchKeyword ='orderNo' AND CONCAT('', oh.orderNumber) LIKE CONCAT('%',:searchInput,'%')) OR " +
+            "(:searchKeyword ='email' AND u.email LIKE CONCAT('%',:searchInput,'%')) OR " +
+            "(:searchKeyword ='itemName' AND od.itemName LIKE CONCAT('%',:searchInput,'%')))"+
+            "AND (:startDate IS NULL OR oh.paymentDate >= :startDate)" +
+            "AND (:endDate IS NULL OR oh.paymentDate <= :endDate)")
+    Page<AdminRefundDTO> findRefund(Pageable pageable,
+                                    @Param("searchKeyword")String searchKeyword,
+                                    @Param("searchInput")String searchInput,
+                                    @Param("startDate") Timestamp startDate,
+                                    @Param("endDate")Timestamp endDate);
+}

--- a/application/src/main/java/com/project/service/Admin/AdminOrderService.java
+++ b/application/src/main/java/com/project/service/Admin/AdminOrderService.java
@@ -3,6 +3,7 @@ package com.project.service.Admin;
 import com.project.dto.*;
 import com.project.repository.admin.AdminExchangeRepository;
 import com.project.repository.admin.AdminOrderRepository;
+import com.project.repository.admin.AdminRefundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,7 @@ import java.util.List;
 public class AdminOrderService {
     private final AdminOrderRepository adminOrderRepository;
     private final AdminExchangeRepository adminExchangeRepository;
+    private final AdminRefundRepository adminRefundRepository;
 
     public Page<AdminOrderDTO> getOrder(Pageable pageable, PageRequestDTO pageRequestDTO) {
         return adminOrderRepository.findOrder(pageable,
@@ -36,6 +38,14 @@ public class AdminOrderService {
 
     public Page<AdminExchangeDTO> getExchange(Pageable pageable, PageRequestDTO pageRequestDTO) {
         return adminExchangeRepository.findExchange(pageable,
+                pageRequestDTO.getSearchKeyword(),
+                pageRequestDTO.getSearchInput(),
+                pageRequestDTO.getStartDate(),
+                pageRequestDTO.getEndDate());
+    }
+
+    public Page<AdminRefundDTO> getRefund(Pageable pageable, PageRequestDTO pageRequestDTO) {
+        return adminRefundRepository.findRefund(pageable,
                 pageRequestDTO.getSearchKeyword(),
                 pageRequestDTO.getSearchInput(),
                 pageRequestDTO.getStartDate(),

--- a/application/src/main/java/com/project/service/Admin/AdminOrderService.java
+++ b/application/src/main/java/com/project/service/Admin/AdminOrderService.java
@@ -1,7 +1,7 @@
 package com.project.service.Admin;
 
 import com.project.dto.*;
-import com.project.repository.admin.AdminDeliveryRepository;
+import com.project.repository.admin.AdminExchangeRepository;
 import com.project.repository.admin.AdminOrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminOrderService {
     private final AdminOrderRepository adminOrderRepository;
-    private final AdminDeliveryRepository adminDeliveryRepository;
+    private final AdminExchangeRepository adminExchangeRepository;
 
     public Page<AdminOrderDTO> getOrder(Pageable pageable, PageRequestDTO pageRequestDTO) {
         return adminOrderRepository.findOrder(pageable,
@@ -28,6 +28,14 @@ public class AdminOrderService {
 
     public Page<AdminDeliveryDTO> getDelivery(Pageable pageable, PageRequestDTO pageRequestDTO) {
         return adminOrderRepository.findDelivery(pageable,
+                pageRequestDTO.getSearchKeyword(),
+                pageRequestDTO.getSearchInput(),
+                pageRequestDTO.getStartDate(),
+                pageRequestDTO.getEndDate());
+    }
+
+    public Page<AdminExchangeDTO> getExchange(Pageable pageable, PageRequestDTO pageRequestDTO) {
+        return adminExchangeRepository.findExchange(pageable,
                 pageRequestDTO.getSearchKeyword(),
                 pageRequestDTO.getSearchInput(),
                 pageRequestDTO.getStartDate(),

--- a/frontend/src/api/admin/order/order.js
+++ b/frontend/src/api/admin/order/order.js
@@ -16,6 +16,22 @@ export const getDelivery = async (params) => {
   });
 };
 
+export const getExchange = async (params) => {
+  const queryString = new URLSearchParams(params).toString();
+  return await fetchAPI(`/api/admin/order/exchange?${queryString}`, {
+    method: 'GET',
+    header: { 'Content-type': 'application/json' },
+  });
+};
+
+export const getRefund = async (params) => {
+  const queryString = new URLSearchParams(params).toString();
+  return await fetchAPI(`/api/admin/order/refund?${queryString}`, {
+    method: 'GET',
+    header: { 'Content-type': 'application/json' },
+  });
+};
+
 export const getOrderMonth = async () => {
   return await fetchAPI('/api/admin/order/month', {
     method: 'GET',

--- a/frontend/src/components/admin/content/order/Exchange.jsx
+++ b/frontend/src/components/admin/content/order/Exchange.jsx
@@ -1,5 +1,102 @@
-import { Form, Button, Row, Col, Table } from 'react-bootstrap';
+import { useEffect, useState } from 'react';
+import { Form, Button, Row, Col, Table, Pagination } from 'react-bootstrap';
+import { getExchange } from '../../../../api/admin/order/order';
 const Exchange = () => {
+  const [exchanges, setExchanges] = useState([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [size, setSize] = useState(20);
+  const [pageGroup, setPageGroup] = useState(0);
+
+  const [searchParams, setSearchParams] = useState({
+    searchKeyword: 'orderNo',
+    searchInput: '',
+    startDate: '',
+    endDate: '',
+  });
+
+  useEffect(() => {
+    fetchExchange(currentPage, size, searchParams);
+  }, []);
+
+  const fetchExchange = (page, size, searchParams) => {
+    const params = {
+      page,
+      size,
+      ...searchParams,
+    };
+    getExchange(params)
+      .then((response) => {
+        setExchanges(response.content);
+        setTotalPages(response.totalPages);
+      })
+      .catch((error) => console.error(error));
+  };
+
+  const updateSearchParams = (key, value) => {
+    setSearchParams((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+  const setDateRange = (range) => {
+    const today = new Date();
+
+    switch (range) {
+      case 'today':
+        updateSearchParams('startDate', formatDate(today));
+        updateSearchParams('endDate', formatDate(today));
+        break;
+
+      case 'week':
+        const oneWeekAgo = new Date(today);
+        oneWeekAgo.setDate(today.getDate() - 7);
+        updateSearchParams('startDate', formatDate(oneWeekAgo));
+        updateSearchParams('endDate', formatDate(today));
+        break;
+
+      case 'month':
+        const oneMonthAgo = new Date(today);
+        oneMonthAgo.setMonth(today.getMonth() - 1);
+        updateSearchParams('startDate', formatDate(oneMonthAgo));
+        updateSearchParams('endDate', formatDate(today));
+        break;
+
+      case 'all':
+        updateSearchParams('startDate', '');
+        updateSearchParams('endDate', '');
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  const formatDate = (date) => {
+    return date.toISOString().split('T')[0];
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+    fetchExchange(page, size, searchParams);
+  };
+
+  const handleSearch = () => {
+    setCurrentPage(0);
+    fetchExchange(0, size, searchParams);
+  };
+
+  const handleReset = () => {
+    setSearchParams({
+      searchKeyword: 'orderNo',
+      searchInput: '',
+      startDate: '',
+      endDate: '',
+    });
+    setCurrentPage(0);
+    setSize(20);
+  };
+
   return (
     <div>
       <h2>교환</h2>
@@ -18,17 +115,32 @@ const Exchange = () => {
             <Col xs={12} md={4} lg={3}>
               <Form.Group controlId="searchKeyword">
                 <Form.Label>검색어</Form.Label>
-                <Form.Control as="select">
-                  <option>아이디</option>
-                  <option>닉네임</option>
-                  <option>이메일</option>
+                <Form.Control
+                  as="select"
+                  name="searchKeyword"
+                  value={searchParams.searchKeyword}
+                  onChange={(e) =>
+                    updateSearchParams('searchKeyword', e.target.value)
+                  }
+                >
+                  <option value="orderNo">주문번호</option>
+                  <option value="email">이메일</option>
+                  <option value="itemName">상품명</option>
                 </Form.Control>
               </Form.Group>
             </Col>
             <Col xs={12} md={8} lg={6}>
               <Form.Group controlId="searchInput">
                 <Form.Label>검색값</Form.Label>
-                <Form.Control type="text" placeholder="검색어 입력" />
+                <Form.Control
+                  name="searchInput"
+                  value={searchParams.searchInput}
+                  type="text"
+                  placeholder="검색어 입력"
+                  onChange={(e) =>
+                    updateSearchParams('searchInput', e.target.value)
+                  }
+                />
               </Form.Group>
             </Col>
           </Row>
@@ -38,8 +150,23 @@ const Exchange = () => {
               <Form.Group controlId="dateRange">
                 <Form.Label>기간검색(교환날짜)</Form.Label>
                 <div className="d-flex align-items-center">
-                  <Form.Control type="date" className="me-2" />
-                  <Form.Control type="date" />
+                  <Form.Control
+                    type="date"
+                    name="startDate"
+                    value={searchParams.startDate}
+                    className="me-2"
+                    onChange={(e) =>
+                      updateSearchParams('startDate', e.target.value)
+                    }
+                  />
+                  <Form.Control
+                    type="date"
+                    name="endDate"
+                    value={searchParams.endDate}
+                    onChange={(e) =>
+                      updateSearchParams('endDate', e.target.value)
+                    }
+                  />
                 </div>
               </Form.Group>
             </Col>
@@ -49,20 +176,42 @@ const Exchange = () => {
             <Col xs={12} md={6} lg={4}>
               <Form.Group>
                 <div className="d-flex gap-2">
-                  <Button variant="outline-dark">오늘</Button>
-                  <Button variant="outline-dark">일주일</Button>
-                  <Button variant="outline-dark">한 달</Button>
-                  <Button variant="outline-dark">전체</Button>
+                  <Button
+                    variant="outline-dark"
+                    onClick={() => setDateRange('today')}
+                  >
+                    오늘
+                  </Button>
+                  <Button
+                    variant="outline-dark"
+                    onClick={() => setDateRange('week')}
+                  >
+                    일주일
+                  </Button>
+                  <Button
+                    variant="outline-dark"
+                    onClick={() => setDateRange('month')}
+                  >
+                    한 달
+                  </Button>
+                  <Button
+                    variant="outline-dark"
+                    onClick={() => setDateRange('all')}
+                  >
+                    전체
+                  </Button>
                 </div>
               </Form.Group>
             </Col>
           </Row>
 
           <div className="d-flex justify-content-end mt-3">
-            <Button variant="dark" className="me-2">
+            <Button variant="dark" className="me-2" onClick={handleSearch}>
               검색
             </Button>
-            <Button variant="outline-secondary">초기화</Button>
+            <Button variant="outline-secondary" onClick={handleReset}>
+              초기화
+            </Button>
           </div>
         </Form>
       </div>
@@ -71,41 +220,67 @@ const Exchange = () => {
         <thead>
           <tr>
             <th>번호</th>
-            <th>주문일</th>
-            <th>교환일</th>
+            <th>이메일</th>
             <th>주문번호</th>
+            <th>상품명</th>
             <th>상품이미지</th>
-            <th>상품이름</th>
             <th>교환사유</th>
-            <th>총주문액</th>
-            <th>교환정보</th>
+            <th>구매날짜</th>
+            <th>교환요청날짜</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>1</td>
-            <td>2024/12/04</td>
-            <td>2024/12/10</td>
-            <td>24120410080576</td>
-            <td>cell</td>
-            <td>선인장 자수패치 반팔T</td>
-            <td>사이즈 안맞음</td>
-            <td>40,000</td>
-            <td>교환대기</td>
-          </tr>
-          <tr>
-            <td>2</td>
-            <td>2024/12/04</td>
-            <td>2024/12/10</td>
-            <td>24120410080576</td>
-            <td>cell</td>
-            <td>선인장 자수패치 반팔T</td>
-            <td>사이즈 안맞음</td>
-            <td>40,000</td>
-            <td>교환대기</td>
-          </tr>
+          {exchanges.map((exchange, index) => (
+            <tr key={exchange.id}>
+              <td>{index + 1 + currentPage * size}</td>
+              <td>{exchange.email}</td>
+              <td>{exchange.orderNumber}</td>
+              <td>{exchange.itemName}</td>
+              <td>{exchange.exchangeImage}</td>
+              <td>{exchange.description}</td>
+              <td>{exchange.orderDate}</td>
+              <td>{exchange.requestedDate}</td>
+            </tr>
+          ))}
         </tbody>
       </Table>
+      <div className="d-flex justify-content-center mt-5">
+        {/* Pagination */}
+        <Pagination>
+          {/** 이전 그룹 버튼 */}
+          <Pagination.Prev
+            hidden={pageGroup === 0}
+            onClick={() => setPageGroup(pageGroup - 1)}
+          >
+            이전
+          </Pagination.Prev>
+          {/** 현재 그룹의 페이지 번호 */}
+          {Array.from(
+            { length: Math.min(10, totalPages - pageGroup * 10) },
+            (_, i) => {
+              const pageNumber = pageGroup * 10 + i;
+              return (
+                <Pagination.Item
+                  key={pageNumber}
+                  active={pageNumber === currentPage}
+                  className={`custom-page-item ${pageNumber === currentPage ? 'custom-active' : ''}`}
+                  onClick={() => handlePageChange(pageNumber)}
+                >
+                  {pageNumber + 1}
+                </Pagination.Item>
+              );
+            }
+          )}
+
+          {/** 다음 그룹 버튼 */}
+          <Pagination.Next
+            hidden={(pageGroup + 1) * 10 >= totalPages}
+            onClick={() => setPageGroup(pageGroup + 1)}
+          >
+            다음
+          </Pagination.Next>
+        </Pagination>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/admin/content/user/UserGrade.jsx
+++ b/frontend/src/components/admin/content/user/UserGrade.jsx
@@ -30,6 +30,7 @@ const UserGrade = () => {
       }
     );
     // .filter((grade) => grade.grade !== '');
+    console.log(updateGrades);
     updateGrade(updateGrades);
     alert('저장되었습니다!');
     fetchGrades();


### PR DESCRIPTION
## 문제 ## 

- 컬럼이름이 `complated` 로 오타로 생성되어있었음
- 각 테이블의 설명(교환설명,반품설명) 컬럼이 누락되어있었음.

## 해결 방법 ##

- 각 테이블의 컬럼이름 'complated_at` -> `completed_at` 으로 변경
- 각 테이블의 `description` 컬럼추가